### PR TITLE
Add .gitignore to manage unnecessary files

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,10 @@
+# Maven関連
+target/
+*.log
+
+# IDE関連
+.idea/
+*.iml
+
+# OS関連
+.DS_Store

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,9 @@
+# Node.js関連
+node_modules/
+npm-debug.log*
+
+# OS関連
+.DS_Store
+
+# Build関連
+build/


### PR DESCRIPTION
This pull request adds `.gitignore` files to the `backend` and `frontend` directories to exclude common files and directories that should not be tracked by Git. The changes ensure that unnecessary files related to builds, IDEs, operating systems, and development tools are ignored.

Backend `.gitignore` updates:

* Added exclusions for Maven-related files (`target/`, `*.log`), IDE-related files (`.idea/`, `*.iml`), and OS-related files (`.DS_Store`).

Frontend `.gitignore` updates:

* Added exclusions for Node.js-related files (`node_modules/`, `npm-debug.log*`), OS-related files (`.DS_Store`), and build-related files (`build/`).